### PR TITLE
Adds Ruby 3.1 and 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.0.0, 2.5.2, 2.2]
+        ruby-version: [3.2, 3.1, "3.0", 2.5, 2.2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Also updates the checkout action version.
Converts 3.0.0 to 3.0 and quotes, to ensure the latest 3.0.x version is loaded for that entry.