### PR TITLE
Fix YARD examples, add README to manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ $ gem install google_search_results
 [Link to the gem page](https://rubygems.org/gems/google_search_results/)
 
 Tested Ruby versions:
+
  - 2.2
  - 2.5.2
  - 3.0.0
 
-see: [GitHub Actions](https://github.com/serpapi/google-search-results-ruby/blob/9cbd9d64786aeff9765a2417ae007a1fb43ab110/.github/workflows/ruby.yml#L16).
+See: [GitHub Actions](https://github.com/serpapi/google-search-results-ruby/blob/9cbd9d64786aeff9765a2417ae007a1fb43ab110/.github/workflows/ruby.yml#L16).
 
 ## Quick start
 
@@ -96,12 +97,14 @@ See the [playground to generate your code.](https://serpapi.com/playground)
 ## Guide
 ### How to set the private API key
 The api_key can be set globally using a singleton pattern.
+
 ```ruby
 GoogleSearch.api_key = "secret_api_key"
 search = GoogleSearch.new(q: "coffee")
 ```
 
 or api_key can be provided for each search.
+
 ```ruby
 search = GoogleSearch.new(q: "coffee", api_key: "secret_api_key")
 ```
@@ -109,6 +112,7 @@ search = GoogleSearch.new(q: "coffee", api_key: "secret_api_key")
 To get the key simply copy/paste from [serpapi.com/dashboard](https://serpapi.com/dashboard).
 
 ### Search API capability for Google
+
 ```ruby
 search_params = {
   q: "search",
@@ -122,7 +126,7 @@ search_params = {
   start: "Pagination Offset",
   api_key: "private key", # copy paste from https://serpapi.com/dashboard
   tbm: "nws|isch|shop",
-  tbs: "custom to be search criteria"
+  tbs: "custom to be search criteria",
   async: true|false # allow async
 }
 
@@ -155,21 +159,25 @@ We love true open source, continuous integration and Test Drive Development (TDD
 The directory test/ includes specification/examples.
 
 Set your api key.
+
 ```bash
 export API_KEY="your secret key"
 ```
 
 Install RSpec
+
 ```bash
 gem install rspec
 ```
 
 To run the test:
+
 ```bash
 rspec test
 ```
 
 or if you prefers Rake
+
 ```bash
 rake test
 ```
@@ -182,23 +190,29 @@ pp location_list
 ```
 
 it prints the first 3 location matching Austin (Texas, Texas, Rochester)
+
 ```ruby
-[{:id=>"585069bdee19ad271e9bc072",
-  :google_id=>200635,
-  :google_parent_id=>21176,
-  :name=>"Austin, TX",
-  :canonical_name=>"Austin,TX,Texas,United States",
-  :country_code=>"US",
-  :target_type=>"DMA Region",
-  :reach=>5560000,
-  :gps=>[-97.7430608, 30.267153],
-  :keys=>["austin", "tx", "texas", "united", "states"]},
-  ...]
+[
+  {
+    id: "585069bdee19ad271e9bc072",
+    google_id: 200635,
+    google_parent_id: 21176,
+    name: "Austin, TX",
+    canonical_name: "Austin,TX,Texas,United States",
+    country_code: "US",
+    target_type: "DMA Region",
+    reach: 5560000,
+    gps: [-97.7430608, 30.267153],
+    keys: ["austin", "tx", "texas", "united", "states"]
+  },
+  #...
+]
 ```
 
 ### Search Archive API
 This API allows to retrieve previous search.
-To do so run a search to save a search_id.
+To do so run a search to save a `search_id`.
+
 ```ruby
 search = GoogleSearch.new(q: "Coffee", location: "Portland")
 original_search = search.get_hash
@@ -212,9 +226,11 @@ search = GoogleSearch.new
 archive_search = search.get_search_archive(search_id)
 pp archive_search
 ```
+
 it prints the search from the archive.
 
 ### Account API
+
 ```ruby
 search = GoogleSearch.new
 pp search.get_account
@@ -230,6 +246,7 @@ image_results_list.each do |image_result|
   puts image_result[:original]
 end
 ```
+
 To download the image: `wget #{image_result[:original]}`
 
 this code prints all the images links,
@@ -270,7 +287,7 @@ shopping_results_list.each do |shopping_result|
 end
 ```
 
-this script prints all the shopping results order by review order with position.
+This script prints all the shopping results order by review order with position.
 
 ### Google Search By Location
 

--- a/google_search_results.gemspec
+++ b/google_search_results.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.description = "Scape localized search results from search engine using SerpApi.com and returns Hash, JSON, raw HTML"
   s.authors     = ["hartator", "jvmvik"]
   s.email       = "hartator@gmail.com"
-  s.files       = [ "lib/google_search_results.rb"] + Dir.glob("lib/search/*.rb")
+  s.files       = [ "README.md", "lib/google_search_results.rb"] + Dir.glob("lib/search/*.rb")
   s.homepage    = "https://github.com/serpapi/google-search-results-ruby"
   s.license     = "MIT"
   s.required_ruby_version = '>= 1.9.2'

--- a/lib/search/apple_store_search.rb
+++ b/lib/search/apple_store_search.rb
@@ -2,21 +2,17 @@ require_relative 'serp_api_search'
 
 # Apple Store Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     term: "laptop",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   term: "laptop",
-#   api_key: "Your SERP API Key"
-# }
+#   search = AppleStoreSearch.new(parameter)
 #
-# search = AppleStoreSearch.new(parameter)
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 # 
 # doc: https://serpapi.com/bing-search-api
 

--- a/lib/search/baidu_search.rb
+++ b/lib/search/baidu_search.rb
@@ -2,21 +2,18 @@ require_relative 'serp_api_search'
 
 # Baidu Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     q: "query",
+#     api_key: "Serp API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   q: "query",
-#   api_key: "Serp API Key"
-# }
+#   search = BaiduSearch.new(parameter)
 #
-# search = BaiduSearch.new(parameter)
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
 # doc: https://serpapi.com/baidu-search-api
 
 class BaiduSearch < SerpApiSearch

--- a/lib/search/bing_search.rb
+++ b/lib/search/bing_search.rb
@@ -2,23 +2,19 @@ require_relative 'serp_api_search'
 
 # Bing Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     q: "query",
+#     location: "city,state,country",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   q: "query",
-#   location: "city,state,country",
-#   api_key: "Your SERP API Key"
-# }
+#   search = BingSearch.new(parameter)
+#   search.params[:location] = "Portland"
 #
-# search = BingSearch.new(parameter)
-# search.params[:location] = "Portland"
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 # 
 # doc: https://serpapi.com/bing-search-api
 

--- a/lib/search/duckduckgo_search.rb
+++ b/lib/search/duckduckgo_search.rb
@@ -2,21 +2,18 @@ require_relative 'serp_api_search'
 
 # Duckduckgo Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     search_query: "query",
+#     api_key: "Serp API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   search_query: "query",
-#   api_key: "Serp API Key"
-# }
+#   search = DuckduckgoSearch.new(parameter)
 #
-# search = DuckduckgoSearch.new(parameter)
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
+# 
 # doc: https://serpapi.com/Duckduckgo-search-api
 
 class DuckduckgoSearch < SerpApiSearch

--- a/lib/search/ebay_search.rb
+++ b/lib/search/ebay_search.rb
@@ -2,22 +2,18 @@ require_relative 'serp_api_search'
 
 # Ebay Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     _nkw: "query",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   _nkw: "query",
-#   api_key: "Your SERP API Key"
-# }
+#   search = EbaySearch.new(parameter)
+#   search.params[:ebay_domain] = "ebay.com"
 #
-# search = EbaySearch.new(parameter)
-# search.params[:ebay_domain] = "ebay.com"
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
 # doc: https://serpapi.com/ebay-search-api
 

--- a/lib/search/google_search.rb
+++ b/lib/search/google_search.rb
@@ -2,31 +2,28 @@ require_relative 'serp_api_search'
 
 # Google Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     q: "query",
+#     google_domain: "Google Domain", 
+#     location: "Location Requested", 
+#     device: device,
+#     hl: "Google UI Language",
+#     gl: "Google Country",
+#     safe: "Safe Search Flag",
+#     num: "Number of Results",
+#     start: "Pagination Offset",
+#     tbm: "to be matched field",
+#     tbs: "to be searched field",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   q: "query",
-#   google_domain: "Google Domain", 
-#   location: "Location Requested", 
-#   device: device,
-#   hl: "Google UI Language",
-#   gl: "Google Country",
-#   safe: "Safe Search Flag",
-#   num: "Number of Results",
-#   start: "Pagination Offset",
-#   tbm: "to be matched field",
-#   tbs: "to be searched field",
-#   api_key: "Your SERP API Key"
-# }
+#   search = GoogleSearch.new(parameter)
+#   search.params[:location] = "Portland"
 #
-# search = GoogleSearch.new(parameter)
-# search.params[:location] = "Portland"
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
 # doc: https://serpapi.com/search-api
 class GoogleSearch < SerpApiSearch

--- a/lib/search/homedepot_search.rb
+++ b/lib/search/homedepot_search.rb
@@ -2,21 +2,18 @@ require_relative 'serp_api_search'
 
 # Homedepot Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     search_query: "query",
+#     api_key: "Serp API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   search_query: "query",
-#   api_key: "Serp API Key"
-# }
+#   search = HomedepotSearch.new(parameter)
 #
-# search = HomedepotSearch.new(parameter)
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
 # doc: https://serpapi.com/Homedepot-search-api
 
 class HomedepotSearch < SerpApiSearch

--- a/lib/search/naver_search.rb
+++ b/lib/search/naver_search.rb
@@ -2,24 +2,20 @@ require_relative 'serp_api_search'
 
 # Naver Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     q: "query",
+#     location: "city,state,country",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   q: "query",
-#   location: "city,state,country",
-#   api_key: "Your SERP API Key"
-# }
+#   search = NaverSearch.new(parameter)
+#   search.params[:location] = "Portland"
 #
-# search = NaverSearch.new(parameter)
-# search.params[:location] = "Portland"
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
-# 
 # doc: https://serpapi.com/bing-search-api
 
 class NaverSearch < SerpApiSearch

--- a/lib/search/serp_api_search.rb
+++ b/lib/search/serp_api_search.rb
@@ -25,14 +25,10 @@ class SerpApiSearch
 
   # constructor
   #
-  # Usage
-  # ---
-  #
-  # ```ruby
-  # require 'google_search'
-  # search = SerpApiSearch.new({q: "coffee", api_key: "secure API key", engine: "google"})
-  # result = search.get_json
-  # ```
+  # @example Usage
+  #   require 'google_search'
+  #   search = SerpApiSearch.new({q: "coffee", api_key: "secure API key", engine: "google"})
+  #   result = search.get_json
   #
   # @param [Hash] params contains requested parameter
   # @param [String] engine google|baidu|google|bing|ebay|yandex (optional or can be set in params)

--- a/lib/search/walmart_search.rb
+++ b/lib/search/walmart_search.rb
@@ -2,21 +2,18 @@ require_relative 'serp_api_search'
 
 # Walmart Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     query: "search keywords",
+#     api_key: "Serp API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   query: "search keywords",
-#   api_key: "Serp API Key"
-# }
+#   search = WalmartSearch.new(parameter)
 #
-# search = WalmartSearch.new(parameter)
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
 # doc: https://serpapi.com/youtube-search-api
 
 class WalmartSearch < SerpApiSearch

--- a/lib/search/yahoo_search.rb
+++ b/lib/search/yahoo_search.rb
@@ -2,22 +2,18 @@ require_relative 'serp_api_search'
 
 # Yahoo Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     p: "query",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   p: "query",
-#   api_key: "Your SERP API Key"
-# }
+#   search = YahooSearch.new(parameter)
+#   search.params[:yahoo_domain] = "fr"
 #
-# search = YahooSearch.new(parameter)
-# search.params[:yahoo_domain] = "fr"
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
 # doc: https://serpapi.com/yahoo-search-api
 

--- a/lib/search/yandex_search.rb
+++ b/lib/search/yandex_search.rb
@@ -2,22 +2,18 @@ require_relative 'serp_api_search'
 
 # Yandex Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     text: "query",
+#     api_key: "Your SERP API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   text: "query",
-#   api_key: "Your SERP API Key"
-# }
+#   search = YandexSearch.new(parameter)
+#   search.params[:yandex_domain] = "yandex.com"
 #
-# search = YandexSearch.new(parameter)
-# search.params[:yandex_domain] = "yandex.com"
-#
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
 # doc: https://serpapi.com/yandex-search-api
 

--- a/lib/search/youtube_search.rb
+++ b/lib/search/youtube_search.rb
@@ -2,21 +2,18 @@ require_relative 'serp_api_search'
 
 # Youtube Search Result for Ruby powered by SerpApi
 #
-# Search API Usage
+# @example Search API Usage
+#   parameter = {
+#     search_query: "query",
+#     api_key: "Serp API Key"
+#   }
 #
-# ```ruby
-# parameter = {
-#   search_query: "query",
-#   api_key: "Serp API Key"
-# }
+#   search = YoutubeSearch.new(parameter)
 #
-# search = YoutubeSearch.new(parameter)
+#   html_results = search.get_html
+#   hash_results = search.get_hash
+#   json_results = search.get_json
 #
-# html_results = search.get_html
-# hash_results = search.get_hash
-# json_results = search.get_json
-#
-# ```
 # doc: https://serpapi.com/youtube-search-api
 
 class YoutubeSearch < SerpApiSearch


### PR DESCRIPTION
API docs are [pretty ugly](https://www.rubydoc.info/gems/google_search_results/2.2.0) - the README.md isn't included in the manifest so rubydoc.info isn't showing users that, and most examples are using incorrect syntax and not rendering correctly.

These commits should fix both issues.